### PR TITLE
fix(ci): unblock a clean install after the TypeScript 5 move

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,5 @@
+# react-scripts 5 lists typescript "^3.2.1 || ^4" as an optional peer, while the
+# @mysten packages declare const type parameters that only TypeScript 5 can
+# parse. npm's strict peer resolution refuses to install that combination, so a
+# clean install fails even though the build itself is fine on TypeScript 5.
+legacy-peer-deps=true


### PR DESCRIPTION
The deploy on main failed at **Install dependencies** right after #68 landed, so the trimmed plugin is not live: nothing was uploaded, and production still serves the previous bundle.

## Cause

`react-scripts@5.0.1` lists `typescript "^3.2.1 || ^4"` as an optional peer. #68 raised TypeScript to 5 because the `@mysten` packages declare `const` type parameters that 4.7 cannot parse. npm's strict peer resolution refuses that pair:

```
npm error Conflicting peer dependency: typescript@4.9.5
npm error   peerOptional typescript@"^3.2.1 || ^4" from react-scripts@5.0.1
```

My local install had succeeded on an already-populated `node_modules`, which is why this only appeared on a clean CI install. That is on me — the local pass masked it.

## Fix

`.npmrc` with `legacy-peer-deps=true`, so CI's plain `npm install` and local installs behave the same without editing the workflow.

## Verification

Resolution only, which is exactly what failed:

| | exit |
| --- | --- |
| `npm install --dry-run` on main | 1, ERESOLVE |
| `npm install --dry-run --legacy-peer-deps` on main | 0 |
| `npm install --dry-run` with this `.npmrc`, no flag | 0 |

The build was already green on TypeScript 5 in #68 (tsc reports no errors across the project, node_modules included). A full clean install could not be reproduced on this machine for an unrelated reason: it runs Node 26, where a postinstall script in the tree dies regardless of this change — old `main` fails the same way.